### PR TITLE
ci: add stale issue/PR bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,68 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Close stale issues
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly, Monday 6am UTC
+  workflow_dispatch: {}   # Allow manual runs
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # Timing
+          days-before-stale: 90
+          days-before-close: 14
+          days-before-pr-stale: 60
+          days-before-pr-close: 14
+
+          # Labels
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+
+          # Messages
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not
+            had recent activity. It will be closed in 14 days if no further
+            activity occurs. If this issue is still relevant, please comment or
+            remove the stale label.
+          close-issue-message: >
+            This issue has been automatically closed due to inactivity.
+            Feel free to reopen if this is still relevant.
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it
+            has not had recent activity. It will be closed in 14 days if no
+            further activity occurs.
+          close-pr-message: >
+            This pull request has been automatically closed due to inactivity.
+            Feel free to reopen if this is still relevant.
+
+          # Exemptions — don't stale triaged or important issues
+          exempt-all-milestones: true
+          exempt-issue-labels: 'bug,security,process,enhancement'
+          exempt-pr-labels: 'bug,security'
+
+          # Limits
+          operations-per-run: 30


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow using [`actions/stale@v9`](https://github.com/actions/stale) to automatically mark and close inactive issues and pull requests.

## Configuration

| Setting | Issues | PRs |
|---|---|---|
| Days before stale | 90 | 60 |
| Days before close | 14 | 14 |
| Schedule | Weekly (Monday 6am UTC) | Weekly (Monday 6am UTC) |

## Exemptions

Items are **never** marked stale if they have:
- Any milestone assigned (v2.5.0, v2.6.0, v3.0.0, etc.)
- Labels: `bug`, `security`, `process`, `enhancement`

This ensures triaged work is protected while truly abandoned issues get cleaned up.

## Manual Trigger

The workflow can also be triggered manually via `workflow_dispatch` for one-off cleanup.

Closes #43